### PR TITLE
Add the ability to specify both admin and push users

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,14 @@ member of the org being managed.
 
 Define your user to repos mapping
 
-```
+```clojure
 (def input
-  {"user1" {:repos ["repo1"]}
-   "user2" {:repos ["repo1" "repo2"]}})
+  {"user1"
+    {:access
+     {:admin ["repo1"] :push ["repo2"]}}
+   "user2"
+    {:access
+     {:admin ["repo1" "repo2"]}})
 ```
 
 Execute run against given GitHub organization with this repo-mapping
@@ -58,11 +62,13 @@ Execute run against given GitHub organization with this repo-mapping
 
 Will add perform the following
 
-* Create teams repo1-contributors and repo2-contributors in organization this-is-a-test-1234
-* Add user1 to repo1-contributors
-* Add user2 to repo1-contributors and repo2-contributors
-* Add grant repo1-contributors push access to repo1
-* Add grant repo2-contributors push access to repo2
+* Create teams repo1-admin, repo1-push, repo2-admin and repo2-admin in organization this-is-a-test-1234
+* Add user1 to repo2-admin and repo2-push
+* Add user2 to repo1-admin, repo2-admin
+* Add grant repo1-push push access to repo1
+* Add grant repo2-push push access to repo2
+* Add grant repo1-admin admin access to repo1
+* Add grant repo2-admin admin access to repo2
 
 ### Custom Validations
 

--- a/src/hubub/core.clj
+++ b/src/hubub/core.clj
@@ -66,8 +66,8 @@
       (add-users-to-repo users-to-add team-name team-id))))
 
 (defn- set-users
-  [org input repo-name team-name valid-user-fn]
-  (let [users (p/repo-users team-name input valid-user-fn)]
+  [org input repo-name team-name valid-user-fn access]
+  (let [users (p/repo-users team-name input valid-user-fn access)]
     (log/info "Setting users for" (p/log-var repo-name) "to" (p/log-var users))
     (set-team-users org team-name users)))
 
@@ -76,7 +76,7 @@
   (doseq [repo-name (github/list-repos org)]
     (doseq [access valid-access]
       (let [team-name (str repo-name "-" access)]
-        (set-users org input repo-name team-name valid-user-fn)))))
+        (set-users org input repo-name team-name valid-user-fn access)))))
 
 (defn- process
   [org input token valid-user-fn]

--- a/src/hubub/core.clj
+++ b/src/hubub/core.clj
@@ -76,7 +76,7 @@
   (doseq [repo-name (github/list-repos org)]
     (doseq [access valid-access]
       (let [team-name (str repo-name "-" access)]
-        (set-users org input repo-name team-name valid-user-fn access)))))
+        (set-users org input repo-name team-name valid-user-fn)))))
 
 (defn- process
   [org input token valid-user-fn]

--- a/src/hubub/core.clj
+++ b/src/hubub/core.clj
@@ -76,7 +76,7 @@
   (doseq [repo-name (github/list-repos org)]
     (doseq [access valid-access]
       (let [team-name (str repo-name "-" access)]
-        (set-users org input repo-name team-name valid-user-fn)))))
+        (set-users org input repo-name team-name valid-user-fn access)))))
 
 (defn- process
   [org input token valid-user-fn]

--- a/src/hubub/core.clj
+++ b/src/hubub/core.clj
@@ -14,18 +14,20 @@
 
 (def valid-access ["push" "admin"])
 
+(defn- create-team
+  [org repo-name]
+  (doseq [access valid-access]
+    (let [team-name (str repo-name "-" access)]
+      (github/create-team org team-name access)
+      (github/associate-repo-with-team org repo-name team-name))))
+
 (defn- create-teams
   [org]
   (let [repos (github/list-repos org)]
     (log/info "Organization" (p/log-var org) "has repos" (p/log-var repos))
       (doseq [repo-name repos]
         (log/info "Starting to create teams for repo" (p/log-var repo-name))
-
-        (doseq [access valid-access]
-          (let [team-name (str repo-name "-" access)]
-            (github/create-team org team-name access)
-            (github/associate-repo-with-team org repo-name team-name)))
-
+        (create-team org repo-name)
         (log/info "Completed creating teams for repo" (p/log-var repo-name)))))
 
 (defn- remove-users-from-repo

--- a/src/hubub/core.clj
+++ b/src/hubub/core.clj
@@ -67,7 +67,7 @@
 
 (defn- set-users
   [org input repo-name team-name valid-user-fn access]
-  (let [users (p/repo-users team-name input valid-user-fn access)]
+  (let [users (p/repo-users repo-name input valid-user-fn access)]
     (log/info "Setting users for" (p/log-var repo-name) "to" (p/log-var users))
     (set-team-users org team-name users)))
 

--- a/src/hubub/core.clj
+++ b/src/hubub/core.clj
@@ -12,23 +12,21 @@
     (log/error message)
     (swap! *errors* conj message)))
 
-(defn repo-contributors-team-name [r] (str r "-contributors"))
-
-(defn repo-admin-team-name [r] (str r "-admin"))
+(def valid-access ["push" "admin"])
 
 (defn- create-teams
   [org]
   (let [repos (github/list-repos org)]
     (log/info "Organization" (p/log-var org) "has repos" (p/log-var repos))
       (doseq [repo-name repos]
-        (let [admin-team (repo-admin-team-name repo-name)
-              contributor-team (repo-contributors-team-name repo-name)]
-          (log/info "Starting to create teams for repo" (p/log-var repo-name))
-          (github/create-team org admin-team "admin")
-          (github/create-team org contributor-team "push")
-          (github/associate-repo-with-team org repo-name admin-team)
-          (github/associate-repo-with-team org repo-name contributor-team)
-          (log/info "Completed creating teams for repo" (p/log-var repo-name))))))
+        (log/info "Starting to create teams for repo" (p/log-var repo-name))
+
+        (doseq [access valid-access]
+          (let [team-name (str repo-name "-" access)]
+            (github/create-team org team-name access)
+            (github/associate-repo-with-team org repo-name team-name)))
+
+        (log/info "Completed creating teams for repo" (p/log-var repo-name)))))
 
 (defn- remove-users-from-repo
   [users team-name team-id]
@@ -76,9 +74,9 @@
 (defn- set-organizaiton-users
   [org input valid-user-fn]
   (doseq [repo-name (github/list-repos org)]
-    (doseq [team-name [(repo-admin-team-name repo-name)
-                       (repo-contributors-team-name repo-name)]]
-      (set-users org input repo-name team-name valid-user-fn))))
+    (doseq [access valid-access]
+      (let [team-name (str repo-name "-" access)]
+        (set-users org input repo-name team-name valid-user-fn)))))
 
 (defn- process
   [org input token valid-user-fn]

--- a/src/hubub/github.clj
+++ b/src/hubub/github.clj
@@ -47,10 +47,8 @@
 
 (defn- user-member-of-team?
   [team-id username]
-  (if (or (user-member-of-team-active? team-id username)
-          (user-member-of-team-pending? team-id username))
-    true
-    false))
+  (or (user-member-of-team-active? team-id username)
+      (user-member-of-team-pending? team-id username)))
 
 (defn create-team
   [org team-name permission]

--- a/src/hubub/github.clj
+++ b/src/hubub/github.clj
@@ -7,8 +7,9 @@
 (def ^:dynamic *auth* (atom {:oauth-token nil}))
 
 ; -- start github functions ---
-(defn- ^:dynamic gh-list-repos [org] (orgs/repos org (assoc @*auth* :all-pages true)))
-(defn- ^:dynamic gh-list-teams [org] (orgs/teams org (assoc @*auth* :all-pages true)))
+(defn auth-all-pages [] (assoc @*auth* :all-pages true))
+(defn- ^:dynamic gh-list-repos [org] (orgs/repos org (assoc (auth-all-pages) :type :all)))
+(defn- ^:dynamic gh-list-teams [org] (orgs/teams org (auth-all-pages)))
 
 (defn- ^:dynamic gh-team-membership
   [team-id username]

--- a/src/hubub/github.clj
+++ b/src/hubub/github.clj
@@ -15,7 +15,7 @@
   [team-id username]
   (tentacles-core/api-call :get "teams/%s/memberships/%s" [team-id username] @*auth*))
 
-(defn- ^:dynamic gh-team-members [team-id] (orgs/team-members team-id))
+(defn- ^:dynamic gh-team-members [team-id] (orgs/team-members team-id @*auth*))
 
 (defn- ^:dynamic gh-team-associated-with-repo?
   [team-id org repo-name]

--- a/src/hubub/github.clj
+++ b/src/hubub/github.clj
@@ -16,17 +16,14 @@
   (let [teams (map :name (@*list-teams-fn* org (assoc @*auth* :all-pages true)))]
     (false? (empty? (some #{team-name} teams)))))
 
-(defn- repo-team-name [r] (str r "-contributors"))
-
 (defn lookup-team-id
   [org team-name]
   (let [teams (@*list-teams-fn* org (assoc @*auth* :all-pages true))]
     (:id (first (filter #(= (:name %) team-name) teams)))))
 
 (defn associate-repo-with-team
-  [org repo-name]
-  (let [team-name (repo-team-name repo-name)
-        team-id (lookup-team-id org team-name)]
+  [org repo-name team-name]
+  (let [team-id (lookup-team-id org team-name)]
     (if (orgs/team-repo? team-id org repo-name @*auth*)
       (log/info "Team" (p/log-var team-name) "already associated with repo" (p/log-var repo-name))
       (do
@@ -56,9 +53,8 @@
     false))
 
 (defn create-team
-  [org repo-name]
-  (let [team-name (repo-team-name repo-name)
-        options (assoc @*auth* :permission "push")]
+  [org team-name permission]
+  (let [options (assoc @*auth* :permission permission)]
     (if (team-exists? org team-name)
       (log/info "Team" (p/log-var team-name) "already exists.")
       (do

--- a/src/hubub/github.clj
+++ b/src/hubub/github.clj
@@ -16,7 +16,7 @@
 
 (defn- gh-team-members [team-id] (orgs/team-members team-id))
 
-(defn- gh-team-associated-with-repo?
+(defn- ^:dynamic gh-team-associated-with-repo?
   [team-id org repo-name]
   (orgs/team-repo? team-id org repo-name @*auth*))
 
@@ -52,7 +52,9 @@
   [org repo-name team-name]
   (let [team-id (lookup-team-id org team-name)]
     (if (gh-team-associated-with-repo? team-id org repo-name)
-      (log/info "Team" (p/log-var team-name) "already associated with repo" (p/log-var repo-name))
+      (do
+        (log/info "Team" (p/log-var team-name) "already associated with repo" (p/log-var repo-name))
+        true)
       (do
         (log/info "team" (p/log-var team-name) "not associated with repo" (p/log-var repo-name) ". Associating...")
         (gh-add-team-to-repo team-id org repo-name)))))

--- a/src/hubub/github.clj
+++ b/src/hubub/github.clj
@@ -10,11 +10,11 @@
 (defn- ^:dynamic gh-list-repos [org] (orgs/repos org (assoc @*auth* :all-pages true)))
 (defn- ^:dynamic gh-list-teams [org] (orgs/teams org (assoc @*auth* :all-pages true)))
 
-(defn- gh-team-membership
+(defn- ^:dynamic gh-team-membership
   [team-id username]
   (tentacles-core/api-call :get "teams/%s/memberships/%s" [team-id username] @*auth*))
 
-(defn- gh-team-members [team-id] (orgs/team-members team-id))
+(defn- ^:dynamic gh-team-members [team-id] (orgs/team-members team-id))
 
 (defn- ^:dynamic gh-team-associated-with-repo?
   [team-id org repo-name]
@@ -34,7 +34,13 @@
   (orgs/delete-team-member team-id user @*auth*))
 
 (defn- gh-add-user-to-team [team-id user] (orgs/add-team-member team-id user @*auth*))
+
 ; -- end github functions ---
+;(gh-team-membership 1 2)
+;(lookup-team-id "hubub-test" "test-repo-2-admin")
+;(user-member-state "2061566" "bweaver")
+;(user-member-state "2061567" "bw-intuit")
+;(swap! *auth* assoc :oauth-token (System/getenv "HUBUB_GITHUB_TOKEN"))
 
 (defn list-repos [org] (map :name (gh-list-repos org)))
 

--- a/src/hubub/github.clj
+++ b/src/hubub/github.clj
@@ -4,35 +4,62 @@
             [hubub.parsers :as p]
             [clojure.tools.logging :as log]))
 
-(def ^:dynamic *list-repos-fn* (atom orgs/repos))
-(def ^:dynamic *list-teams-fn* (atom orgs/teams))
-(def ^:dynamic *create-team-fn* (atom orgs/create-team))
 (def ^:dynamic *auth* (atom {:oauth-token nil}))
 
-(defn list-repos [org] (map :name (@*list-repos-fn* org (assoc @*auth* :all-pages true))))
+; -- start github functions ---
+(defn- ^:dynamic gh-list-repos [org] (orgs/repos org (assoc @*auth* :all-pages true)))
+(defn- ^:dynamic gh-list-teams [org] (orgs/teams org (assoc @*auth* :all-pages true)))
+
+(defn- gh-team-membership
+  [team-id username]
+  (tentacles-core/api-call :get "teams/%s/memberships/%s" [team-id username] @*auth*))
+
+(defn- gh-team-members [team-id] (orgs/team-members team-id))
+
+(defn- gh-team-associated-with-repo?
+  [team-id org repo-name]
+  (orgs/team-repo? team-id org repo-name @*auth*))
+
+(defn- gh-add-team-to-repo
+  [team-id org repo-name]
+  (orgs/add-team-repo team-id org repo-name @*auth*))
+
+(defn- ^:dynamic gh-create-team
+  [org team-name permission]
+  (let [options (assoc @*auth* :permission permission)]
+    (orgs/create-team org team-name options)))
+
+(defn- gh-remove-user-from-team
+  [team-id user]
+  (orgs/delete-team-member team-id user @*auth*))
+
+(defn- gh-add-user-to-team [team-id user] (orgs/add-team-member team-id user @*auth*))
+; -- end github functions ---
+
+(defn list-repos [org] (map :name (gh-list-repos org)))
 
 (defn team-exists?
   [org team-name]
-  (let [teams (map :name (@*list-teams-fn* org (assoc @*auth* :all-pages true)))]
+  (let [teams (map :name (gh-list-teams org))]
     (false? (empty? (some #{team-name} teams)))))
 
 (defn lookup-team-id
   [org team-name]
-  (let [teams (@*list-teams-fn* org (assoc @*auth* :all-pages true))]
+  (let [teams (gh-list-teams org)]
     (:id (first (filter #(= (:name %) team-name) teams)))))
 
 (defn associate-repo-with-team
   [org repo-name team-name]
   (let [team-id (lookup-team-id org team-name)]
-    (if (orgs/team-repo? team-id org repo-name @*auth*)
+    (if (gh-team-associated-with-repo? team-id org repo-name)
       (log/info "Team" (p/log-var team-name) "already associated with repo" (p/log-var repo-name))
       (do
         (log/info "team" (p/log-var team-name) "not associated with repo" (p/log-var repo-name) ". Associating...")
-        (orgs/add-team-repo team-id org repo-name @*auth*)))))
+        (gh-add-team-to-repo team-id org repo-name)))))
 
 (defn- user-member-state
   [team-id username]
-  (let [result (tentacles-core/api-call :get "teams/%s/memberships/%s" [team-id username] @*auth*)]
+  (let [result (gh-team-membership team-id username)]
     (:state result)))
 
 (defn user-member-of-team-pending?
@@ -52,25 +79,20 @@
 
 (defn create-team
   [org team-name permission]
-  (let [options (assoc @*auth* :permission permission)]
-    (if (team-exists? org team-name)
-      (log/info "Team" (p/log-var team-name) "already exists.")
-      (do
-        (log/info "Team" (p/log-var team-name) "does not exist. creating.")
-        (@*create-team-fn* org team-name options)))))
+  (if (team-exists? org team-name)
+    (log/info "Team" (p/log-var team-name) "already exists.")
+    (do
+      (log/info "Team" (p/log-var team-name) "does not exist. creating.")
+      (gh-create-team org team-name permission))))
 
 (defn add-user-to-team
   [id user]
   (if (user-member-of-team? id user)
     true
-    (orgs/add-team-member id user @*auth*)))
+    (gh-add-user-to-team id user)))
 
-(defn remove-user-from-team
-  [id user]
-  (orgs/delete-team-member id user @*auth*))
+(defn remove-user-from-team [id user] (gh-remove-user-from-team id user))
 
-(defn current-users-in-team [id] (map :login (orgs/team-members id @*auth*)))
+(defn current-users-in-team [id] (map :login (gh-team-members id)))
 
-(defn set-github-token
-  [token]
-  (swap! *auth* assoc :oauth-token token))
+(defn set-github-token [token] (swap! *auth* assoc :oauth-token token))

--- a/src/hubub/github.clj
+++ b/src/hubub/github.clj
@@ -35,13 +35,6 @@
 
 (defn- gh-add-user-to-team [team-id user] (orgs/add-team-member team-id user @*auth*))
 
-; -- end github functions ---
-;(gh-team-membership 1 2)
-;(lookup-team-id "hubub-test" "test-repo-2-admin")
-;(user-member-state "2061566" "bweaver")
-;(user-member-state "2061567" "bw-intuit")
-;(swap! *auth* assoc :oauth-token (System/getenv "HUBUB_GITHUB_TOKEN"))
-
 (defn list-repos [org] (map :name (gh-list-repos org)))
 
 (defn team-exists?

--- a/src/hubub/github.clj
+++ b/src/hubub/github.clj
@@ -20,7 +20,7 @@
   [team-id org repo-name]
   (orgs/team-repo? team-id org repo-name @*auth*))
 
-(defn- gh-add-team-to-repo
+(defn- ^:dynamic gh-add-team-to-repo
   [team-id org repo-name]
   (orgs/add-team-repo team-id org repo-name @*auth*))
 

--- a/src/hubub/parsers.clj
+++ b/src/hubub/parsers.clj
@@ -9,8 +9,6 @@
 (defmethod log-var Number [x] (str "'" x "'"))
 (defmethod log-var String [x] (str "'" x "'"))
 
-(defn- valid-user? [username user-data valid-user-fn] (valid-user-fn username user-data))
-
 (defn parse-repos-to-users
   [input role]
   (loop [users input result {}]
@@ -18,7 +16,7 @@
         result
         (let [user (first users)
               username (first user)
-              repos (get (last user) role)]
+              repos (get (get (last user) "access") role)]
           (recur (rest users) (loop [r repos result2 result]
                                 (if (empty? r)
                                   result2
@@ -30,10 +28,10 @@
   [repo-name input valid-user-fn role]
   (let [repos-user-map (parse-repos-to-users input role)
         repo-user-map (get repos-user-map repo-name)
-        valid-repo-users (filter (fn [username]
-                                   (let [user-data (get input username)]
-                                     (valid-user? username user-data valid-user-fn)))
-                                 repo-user-map)]
+        filter-fn (fn [username]
+                    (let [user-data (get input username)]
+                      (valid-user-fn username user-data)))
+        valid-repo-users (filter filter-fn repo-user-map)]
     (do
       (log/info "Valid repo users for" (log-var repo-name) "are" (log-var valid-repo-users))
       valid-repo-users)))

--- a/src/hubub/parsers.clj
+++ b/src/hubub/parsers.clj
@@ -10,13 +10,13 @@
 (defmethod log-var String [x] (str "'" x "'"))
 
 (defn parse-repos-to-users
-  [input role]
+  [input access]
   (loop [users input result {}]
     (if (empty? users)
         result
         (let [user (first users)
               username (first user)
-              repos (get (get (last user) "access") role)]
+              repos (get (get (last user) "access") access)]
           (recur (rest users) (loop [r repos result2 result]
                                 (if (empty? r)
                                   result2
@@ -25,8 +25,8 @@
                                            (assoc result2 repo (vec (concat (get result2 repo) [username]))))))))))))
 
 (defn repo-users
-  [repo-name input valid-user-fn role]
-  (let [repos-user-map (parse-repos-to-users input role)
+  [repo-name input valid-user-fn access]
+  (let [repos-user-map (parse-repos-to-users input access)
         repo-user-map (get repos-user-map repo-name)
         filter-fn (fn [username]
                     (let [user-data (get input username)]

--- a/src/hubub/parsers.clj
+++ b/src/hubub/parsers.clj
@@ -12,13 +12,13 @@
 (defn- valid-user? [username user-data valid-user-fn] (valid-user-fn username user-data))
 
 (defn parse-repos-to-users
-  [input]
+  [input role]
   (loop [users input result {}]
     (if (empty? users)
         result
         (let [user (first users)
               username (first user)
-              repos (get (last user) "repos")]
+              repos (get (last user) role)]
           (recur (rest users) (loop [r repos result2 result]
                                 (if (empty? r)
                                   result2
@@ -27,8 +27,8 @@
                                            (assoc result2 repo (vec (concat (get result2 repo) [username]))))))))))))
 
 (defn repo-users
-  [repo-name input valid-user-fn]
-  (let [repos-user-map (parse-repos-to-users input)
+  [repo-name input valid-user-fn role]
+  (let [repos-user-map (parse-repos-to-users input role)
         repo-user-map (get repos-user-map repo-name)
         valid-repo-users (filter (fn [username]
                                    (let [user-data (get input username)]

--- a/test/hubub/github_test.clj
+++ b/test/hubub/github_test.clj
@@ -55,3 +55,11 @@
       (binding [hubub.github/gh-team-associated-with-repo? (fn [team-id org repo-name] false)
                 hubub.github/gh-add-team-to-repo (fn [team-id org repo-name] false)]
         (is (false? (associate-repo-with-team "org" "repo" "Owners")))))))
+
+(deftest user-member-of-team-pending-test
+  (testing "is pending"
+    (binding [hubub.github/gh-team-membership team-membership-pending]
+      (is (true? (user-member-of-team-pending? "123" "bw-intuit")))))
+  (testing "is active"
+    (binding [hubub.github/gh-team-membership team-membership-active]
+      (is (false? (user-member-of-team-pending? "123" "bw-intuit"))))))

--- a/test/hubub/github_test.clj
+++ b/test/hubub/github_test.clj
@@ -15,6 +15,8 @@
     (testing "valid team returns false"
       (is (= (team-exists? "org" "invalid") false)))))
 
+(list-teams-stub-success "test")
+
 (deftest create-team-test
   (binding [hubub.github/gh-create-team create-team-stub-success]
     (testing "create team"

--- a/test/hubub/github_test.clj
+++ b/test/hubub/github_test.clj
@@ -3,29 +3,24 @@
             [hubub.github :refer :all]
             [hubub.stubs :refer :all]))
 
-(defn stub-all
-  []
-  (reset! *auth* {:oauth-token "abc"})
-  (reset! *list-repos-fn* list-repos-stub-fn)
-  (reset! *list-teams-fn* list-teams-stub-fn)
-  (reset! *create-team-fn* create-team-stub-fn))
-
 (deftest verify-list-repos
   (testing "verify listing repos"
-    (do
-      (stub-all)
+    (binding [hubub.github/gh-list-repos list-repos-stub-success]
       (is (= (list-repos "org") ["project1"])))))
 
 (deftest team-exists-test
-  (do
-    (stub-all)
+  (binding [hubub.github/gh-list-teams list-teams-stub-success]
     (testing "valid team returns true"
       (is (= (team-exists? "org" "Owners") true)))
     (testing "valid team returns false"
       (is (= (team-exists? "org" "invalid") false)))))
 
 (deftest create-team-test
-  (do
-    (stub-all)
+  (binding [hubub.github/gh-create-team create-team-stub-success]
     (testing "create team"
       (is (= (:name (create-team "org" "team1-push" "admin")) "team1-push")))))
+
+(deftest list-repos-test
+  (let [stub (fn [org] '({:name "test1234"} {:name "test4321"}))]
+    (binding [hubub.github/gh-list-repos stub]
+      (is (= (list-repos "test") ["test1234" "test4321"])))))

--- a/test/hubub/github_test.clj
+++ b/test/hubub/github_test.clj
@@ -28,5 +28,5 @@
   (do
     (stub-all)
     (testing "create team"
-      (is (= (:name (create-team "org" "team1")) "team1-contributors")))))
+      (is (= (:name (create-team "org" "team1-contributors" "admin")) "team1-contributors")))))
 

--- a/test/hubub/github_test.clj
+++ b/test/hubub/github_test.clj
@@ -15,14 +15,25 @@
     (testing "valid team returns false"
       (is (= (team-exists? "org" "invalid") false)))))
 
-(list-teams-stub-success "test")
-
 (deftest create-team-test
   (binding [hubub.github/gh-create-team create-team-stub-success]
     (testing "create team"
       (is (= (:name (create-team "org" "team1-push" "admin")) "team1-push")))))
 
 (deftest list-repos-test
-  (let [stub (fn [org] '({:name "test1234"} {:name "test4321"}))]
-    (binding [hubub.github/gh-list-repos stub]
-      (is (= (list-repos "test") ["test1234" "test4321"])))))
+  (binding [hubub.github/gh-list-repos list-repos-stub-success]
+    (testing "success"
+      (is (= (list-repos "test") ["project1"])))))
+
+(deftest lookup-team-id-test
+  (binding [hubub.github/gh-list-teams list-teams-stub-success]
+    (testing "returns the team id"
+      (is (= (lookup-team-id "org" "Owners") 123))))
+    (testing "returns nil for unknown team"
+      (is (nil? (lookup-team-id "org" "blah")))))
+
+(deftest associate-repo-with-team-test
+  (binding [hubub.github/gh-list-teams list-teams-stub-success
+            hubub.github/gh-team-associated-with-repo? (fn [team-id org repo-name] true)]
+    (testing "org already associated"
+      (is (true? (associate-repo-with-team "org" "repo" "Owners"))))))

--- a/test/hubub/github_test.clj
+++ b/test/hubub/github_test.clj
@@ -28,5 +28,4 @@
   (do
     (stub-all)
     (testing "create team"
-      (is (= (:name (create-team "org" "team1-contributors" "admin")) "team1-contributors")))))
-
+      (is (= (:name (create-team "org" "team1-push" "admin")) "team1-push")))))

--- a/test/hubub/parsers_test.clj
+++ b/test/hubub/parsers_test.clj
@@ -5,13 +5,20 @@
 
 (deftest verify-repo-users
   (testing "make sure filters proper users"
-    (is (= (repo-users "repo1" input valid-user-stub-fn)
+    (is (= (repo-users "repo1" input valid-user-stub-fn "contributor")
            ["github-user1" "github-user3"]))
-    (is (= (repo-users "repo2" input valid-user-stub-fn)
+    (is (= (repo-users "repo1" input valid-user-stub-fn "admin")
+           ["github-user3"]))
+    (is (= (repo-users "repo2" input valid-user-stub-fn "contributor")
+           ["github-user3"]))
+    (is (= (repo-users "repo2" input valid-user-stub-fn "admin")
            ["github-user3"]))))
 
 (deftest parse-repos-to-user-test
   (testing "test parse-repos-to-user"
-    (is (= (parse-repos-to-users input)
+    (is (= (parse-repos-to-users input "admin")
+           {"repo1" ["github-user2" "github-user3"]
+            "repo2" ["github-user3"]}))
+    (is (= (parse-repos-to-users input "contributor")
            {"repo1" ["github-user1" "github-user2" "github-user3"]
             "repo2" ["github-user2" "github-user3"]}))))

--- a/test/hubub/parsers_test.clj
+++ b/test/hubub/parsers_test.clj
@@ -5,11 +5,11 @@
 
 (deftest verify-repo-users
   (testing "make sure filters proper users"
-    (is (= (repo-users "repo1" input valid-user-stub-fn "contributor")
+    (is (= (repo-users "repo1" input valid-user-stub-fn "push")
            ["github-user1" "github-user3"]))
     (is (= (repo-users "repo1" input valid-user-stub-fn "admin")
            ["github-user3"]))
-    (is (= (repo-users "repo2" input valid-user-stub-fn "contributor")
+    (is (= (repo-users "repo2" input valid-user-stub-fn "push")
            ["github-user3"]))
     (is (= (repo-users "repo2" input valid-user-stub-fn "admin")
            ["github-user3"]))))
@@ -19,6 +19,6 @@
     (is (= (parse-repos-to-users input "admin")
            {"repo1" ["github-user2" "github-user3"]
             "repo2" ["github-user3"]}))
-    (is (= (parse-repos-to-users input "contributor")
+    (is (= (parse-repos-to-users input "push")
            {"repo1" ["github-user1" "github-user2" "github-user3"]
             "repo2" ["github-user2" "github-user3"]}))))

--- a/test/hubub/stubs.clj
+++ b/test/hubub/stubs.clj
@@ -32,8 +32,8 @@
   {:html_url "https://github.com/org/project1"
    :name "project1"})
 
-(defn list-teams-stub-success [org] '(team-response))
+(defn list-teams-stub-success [org] [team-response])
 
-(defn list-repos-stub-success [org] '(repo-response))
+(defn list-repos-stub-success [org] [repo-response])
 
 (defn create-team-stub-success [org team-name permission] {:name team-name})

--- a/test/hubub/stubs.clj
+++ b/test/hubub/stubs.clj
@@ -25,7 +25,8 @@
    :permission "admin",
    :name "Owners",
    :privacy "secret",
-   :id 123, :url "https://api.github.com/teams/123",
+   :id 123,
+   :url "https://api.github.com/teams/123",
    :repositories_url "https://api.github.com/teams/123"})
 
 (def repo-response

--- a/test/hubub/stubs.clj
+++ b/test/hubub/stubs.clj
@@ -33,6 +33,19 @@
   {:html_url "https://github.com/org/project1"
    :name "project1"})
 
+(def pending-membership
+  {:state "pending"
+   :role "member"
+   :url "https://api.github.com/teams/2061567/memberships/bw-intuit"})
+
+(def active-membership
+  {:state "active"
+   :role "member"
+   :url "https://api.github.com/teams/2061567/memberships/bw-intuit"})
+
+(defn team-membership-active [team-id username] active-membership)
+(defn team-membership-pending [team-id username] pending-membership)
+
 (defn list-teams-stub-success [org] [team-response])
 
 (defn list-repos-stub-success [org] [repo-response])

--- a/test/hubub/stubs.clj
+++ b/test/hubub/stubs.clj
@@ -18,23 +18,22 @@
               "admin" ["repo1" "repo2"]}
     "internal-user" "internal-user3"}})
 
-(defn list-teams-stub-fn
-  [org auth]
-  '({:description nil,
-     :members_url "https://api.github.com/teams/123{/member}",
-     :slug "owners",
-     :permission "admin",
-     :name "Owners",
-     :privacy "secret",
-     :id 123, :url "https://api.github.com/teams/123",
-     :repositories_url "https://api.github.com/teams/123"}))
+(def team-response
+  {:description nil,
+   :members_url "https://api.github.com/teams/123{/member}",
+   :slug "owners",
+   :permission "admin",
+   :name "Owners",
+   :privacy "secret",
+   :id 123, :url "https://api.github.com/teams/123",
+   :repositories_url "https://api.github.com/teams/123"})
 
+(def repo-response
+  {:html_url "https://github.com/org/project1"
+   :name "project1"})
 
-(defn list-repos-stub-fn
-  [org auth]
-  [{:html_url "https://github.com/org/project1"
-    :name "project1"}])
+(defn list-teams-stub-success [org] '(team-response))
 
-(defn create-team-stub-fn
-  [org team-name options]
-  {:name team-name})
+(defn list-repos-stub-success [org] '(repo-response))
+
+(defn create-team-stub-success [org team-name permission] {:name team-name})

--- a/test/hubub/stubs.clj
+++ b/test/hubub/stubs.clj
@@ -6,11 +6,13 @@
         ["internal-user1" "internal-user3"]))
 
 (def input
-  {"github-user1" {"repos" ["repo1"]
+  {"github-user1" {"contributor" ["repo1"]
                    "internal-user" "internal-user1"}
-   "github-user2" {"repos" ["repo1" "repo2"]
+   "github-user2" {"contributor" ["repo1" "repo2"]
+                   "admin" ["repo1"]
                    "internal-user" "internal-user2"}
-   "github-user3" {"repos" ["repo1" "repo2"]
+   "github-user3" {"contributor" ["repo1" "repo2"]
+                   "admin" ["repo1" "repo2"]
                    "internal-user" "internal-user3"}})
 
 (defn list-teams-stub-fn

--- a/test/hubub/stubs.clj
+++ b/test/hubub/stubs.clj
@@ -6,14 +6,17 @@
         ["internal-user1" "internal-user3"]))
 
 (def input
-  {"github-user1" {"contributor" ["repo1"]
-                   "internal-user" "internal-user1"}
-   "github-user2" {"contributor" ["repo1" "repo2"]
-                   "admin" ["repo1"]
-                   "internal-user" "internal-user2"}
-   "github-user3" {"contributor" ["repo1" "repo2"]
-                   "admin" ["repo1" "repo2"]
-                   "internal-user" "internal-user3"}})
+  {"github-user1"
+   {"access" {"push" ["repo1"]}
+    "internal-user" "internal-user1"}
+   "github-user2"
+   {"access" {"push" ["repo1" "repo2"]
+              "admin" ["repo1"]}
+    "internal-user" "internal-user2"}
+   "github-user3"
+   {"access" {"push" ["repo1" "repo2"]
+              "admin" ["repo1" "repo2"]}
+    "internal-user" "internal-user3"}})
 
 (defn list-teams-stub-fn
   [org auth]


### PR DESCRIPTION
Breaking change, will require us to cleanup old groups.
